### PR TITLE
Fix context path appent twice to workspace dir

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/dockerslaves/DockerfileContainerDefinition.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/dockerslaves/DockerfileContainerDefinition.java
@@ -75,14 +75,13 @@ public class DockerfileContainerDefinition extends ContainerDefinition {
         String tag = Long.toHexString(System.nanoTime());
 
         final FilePath workspace = procStarter.pwd();
-        FilePath contextRoot = workspace.child(contextPath);
 
-        final FilePath pathToContext = contextRoot.child(contextPath);
+        final FilePath pathToContext = workspace.child(contextPath);
         if (!pathToContext.exists()) {
             throw new IOException(pathToContext.getRemote() + " does not exists.");
         }
 
-        final FilePath pathToDockerfile = contextRoot.child(dockerfile);
+        final FilePath pathToDockerfile = pathToContext.child(dockerfile);
         if (!pathToDockerfile.exists()) {
             throw new IOException( pathToContext.getRemote() + " does not exists.");
         }


### PR DESCRIPTION
When building in a context different than '.', we get an error like '/home/jenkins/workspace/<workspace>/<dir>/<dir> does not exists.'