### PR TITLE
Fix failure in case when previously built image from Dockerfile is gone

### DIFF
--- a/src/main/java/it/dockins/dockerslaves/spec/DockerfileContainerDefinition.java
+++ b/src/main/java/it/dockins/dockerslaves/spec/DockerfileContainerDefinition.java
@@ -69,7 +69,7 @@ public class DockerfileContainerDefinition extends ContainerDefinition {
     @Override
     public String getImage(DockerDriver driver, FilePath workspace, TaskListener listener) throws IOException, InterruptedException {
         boolean pull = forcePull;
-        if (image != null) return image;
+        if (image != null && driver.checkImageExists(listener, image)) return image;
         String tag = Long.toHexString(System.nanoTime());
 
         final FilePath pathToContext = workspace.child(contextPath);


### PR DESCRIPTION
After docker image is built from Dockerfile we cache image id and reuse it for the next builds.

In the scenario when docker host is changed or some of the images become wiped / broken builds start failing with errors like that:

```
Unable to find image '12345a6b78ch9:latest' locally
Error response from daemon: pull access denied for 12345a6b78ch9, repository does not exist or may require 'docker login'
FATAL: command execution failed
```

This PR fixes it by rebuilding the image in case when it is gone